### PR TITLE
chore: apply direct IP fallback proxy and update host update script m…

### DIFF
--- a/data/nginx/custom/open-webui.conf
+++ b/data/nginx/custom/open-webui.conf
@@ -1,0 +1,114 @@
+# webui.local and vtuber.local configurations
+server {
+    listen 80;
+    server_name webui.local;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 80;
+    server_name vtuber.local;
+    return 301 https://$host$request_uri;
+}
+
+# Fallback for direct IP access - redirect to webui
+server {
+    listen 80;
+    server_name localhost atlantis.local 192.168.4.243;
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS configuration for webui.local
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name webui.local;
+    
+    ssl_certificate /etc/ssl/custom/certificate.crt;
+    ssl_certificate_key /etc/ssl/custom/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    
+    # Debug logging
+    error_log /var/log/nginx/webui-error.log debug;
+    access_log /var/log/nginx/webui-access.log;
+    
+    location / {
+        proxy_pass http://open-webui:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Increased timeouts
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_read_timeout 300s;
+        
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+
+# HTTPS configuration for vtuber.local
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name vtuber.local;
+    
+    ssl_certificate /etc/ssl/custom/certificate.crt;
+    ssl_certificate_key /etc/ssl/custom/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    
+    # Debug logging
+    error_log /var/log/nginx/vtuber-error.log debug;
+    access_log /var/log/nginx/vtuber-access.log;
+    
+    location / {
+        # Using IP address directly instead of host.docker.internal
+        proxy_pass http://192.168.4.243:12393/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # Debug header
+        add_header X-Debug-Info "Proxying to http://192.168.4.243:12393/" always;
+        
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+}
+
+# HTTPS fallback for direct IP access
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name localhost atlantis.local 192.168.4.243;
+    
+    ssl_certificate /etc/ssl/custom/certificate.crt;
+    ssl_certificate_key /etc/ssl/custom/private.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    
+    # Proxy all direct IP requests to Open WebUI
+    location / {
+        proxy_pass http://open-webui:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+} 

--- a/update_webui_host.sh
+++ b/update_webui_host.sh
@@ -28,6 +28,9 @@ fi
 
 echo -e "${GREEN}Found IP address: ${IP_ADDRESS}${NC}"
 
+# Use IP-based hostname for external devices
+HOST_ENTRY="$IP_ADDRESS"
+
 # Check if atlantis.local is already in the hosts file
 if grep -q "atlantis.local" /etc/hosts; then
   echo -e "${YELLOW}Updating existing atlantis.local entry in hosts file...${NC}"
@@ -44,6 +47,8 @@ fi
 # Restart nginx container
 echo -e "${YELLOW}Restarting nginx container...${NC}"
 docker compose restart nginx
+
+echo -e "${GREEN}Hosts updated; use http://${IP_ADDRESS}/webui on other devices${NC}"
 
 echo -e "${GREEN}Done! atlantis.local has been updated to point to ${IP_ADDRESS}${NC}"
 echo -e "${YELLOW}You can now access Open WebUI at https://atlantis.local/webui${NC}"


### PR DESCRIPTION
PR Title: Enable Direct IP Access for Open WebUI and VTuber

Summary:
- HTTP fallback for direct‐IP requests now redirects to `https://$host$request_uri` instead of forcing `webui.local`
- HTTPS fallback for IP access proxies straight to the WebUI container (`open-webui:8080`)
- Updated `update_webui_host.sh` to display the IP‐based URL (`http://<IP>/webui`) for external devices after hosts file update

